### PR TITLE
Fix generated package name

### DIFF
--- a/claymore/src/main/kotlin/com/alecarnevale/claymore/Constants.kt
+++ b/claymore/src/main/kotlin/com/alecarnevale/claymore/Constants.kt
@@ -1,5 +1,0 @@
-package com.alecarnevale.claymore
-
-internal object Constants {
-  const val packageName = "com.alecarnevale.claymore"
-}

--- a/claymore/src/main/kotlin/com/alecarnevale/claymore/generator/ModuleWriter.kt
+++ b/claymore/src/main/kotlin/com/alecarnevale/claymore/generator/ModuleWriter.kt
@@ -22,7 +22,7 @@ internal class ModuleWriter(
 
   fun write(): FileSpec {
     val fileSpec = FileSpec.builder(
-      packageName = Constants.packageName,
+      packageName = interfaceDeclaration.toClassName().packageName,
       fileName = interfaceDeclaration.moduleClassName()
     )
 

--- a/claymore/src/main/kotlin/com/alecarnevale/claymore/generator/ModuleWriter.kt
+++ b/claymore/src/main/kotlin/com/alecarnevale/claymore/generator/ModuleWriter.kt
@@ -1,6 +1,5 @@
 package com.alecarnevale.claymore.generator
 
-import com.alecarnevale.claymore.Constants
 import com.alecarnevale.claymore.generator.utils.bindsAnnotation
 import com.alecarnevale.claymore.generator.utils.installInAnnotation
 import com.alecarnevale.claymore.generator.utils.moduleAnnotation

--- a/claymore/src/test/kotlin/com/alecarnevale/claymore/processor/AutobindProcessorProviderTest.kt
+++ b/claymore/src/test/kotlin/com/alecarnevale/claymore/processor/AutobindProcessorProviderTest.kt
@@ -129,14 +129,12 @@ class AutobindProcessorProviderTest {
 
     assertEquals(KotlinCompilation.ExitCode.OK, result.result.exitCode)
 
-    result.assertGeneratedSources("com/alecarnevale/claymore/FooModule.kt")
+    result.assertGeneratedSources("com/example/FooModule.kt")
     result.assertGeneratedContent(
-      "com/alecarnevale/claymore/FooModule.kt",
+      "com/example/FooModule.kt",
       """
-      package com.alecarnevale.claymore
+      package com.example
       
-      import com.example.Bar
-      import com.example.Foo
       import dagger.Binds
       import dagger.Module
       import dagger.hilt.InstallIn

--- a/demo/src/main/java/com/alessandro/claymore/demo/di/FooProviderModule.kt
+++ b/demo/src/main/java/com/alessandro/claymore/demo/di/FooProviderModule.kt
@@ -1,7 +1,7 @@
 package com.alessandro.claymore.demo.di
 
 // Not used, Autobind annotation will generate this automatically ;)
-// after a successful build take a look at :demo/build/generated/ksp/debug/kotlin/com/alecarnevale/claymore/FooProviderModule
+// after a successful build take a look at :demo/build/generated/ksp/debug/kotlin/com/alessandro/claymore/demo/modelproviders
 
 /*
 import com.alessandro.claymore.demo.modelproviders.FooProvider


### PR DESCRIPTION
Use interface declaration itself, instead of constants.