### PR TITLE
Fix symbol validation

### DIFF
--- a/processors/src/main/kotlin/com/alecarnevale/claymore/validators/InterfaceAutoBindsValidator.kt
+++ b/processors/src/main/kotlin/com/alecarnevale/claymore/validators/InterfaceAutoBindsValidator.kt
@@ -6,14 +6,13 @@ import com.google.devtools.ksp.symbol.ClassKind
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.Modifier
-import com.google.devtools.ksp.validate
 
 /**
  * This validator check if annotated symbols is an interface.
  */
 internal class InterfaceAutoBindsValidator(private val logger: KSPLogger) {
   fun isValid(symbol: KSAnnotated): Boolean {
-    return symbol.validate() && symbol.isAnInterface()
+    return symbol.isAnInterface()
   }
 
   private fun KSAnnotated.isAnInterface(): Boolean {

--- a/processors/src/main/kotlin/com/alecarnevale/claymore/visitors/AutoBindsVisitor.kt
+++ b/processors/src/main/kotlin/com/alecarnevale/claymore/visitors/AutoBindsVisitor.kt
@@ -26,27 +26,9 @@ internal class AutoBindsVisitor(
   override fun visitClassDeclaration(classDeclaration: KSClassDeclaration, data: Unit) {
     logger.info("$TAG visitClassDeclaration of $classDeclaration")
 
-    // check that the class implements an interface only
-    val superTypes = classDeclaration.superTypes
-    val superType = when (superTypes.count()) {
-      0 -> {
-        logger.error("$TAG $classDeclaration musts implement an interface.")
-        return
-      }
-
-      1 -> {
-        superTypes.single()
-      }
-
-      else -> {
-        logger.error("$TAG $classDeclaration musts implement at most one interface.")
-        return
-      }
-    }
-
     // get the KSClassDeclaration of the interface implemented
     val interfaceDeclaration =
-      superType.resolve().declaration.qualifiedName?.let { resolver.getClassDeclarationByName(it) }
+      classDeclaration.superTypes.single().resolve().declaration.qualifiedName?.let { resolver.getClassDeclarationByName(it) }
     if (interfaceDeclaration == null || interfaceDeclaration.isNotValidSupertype()) {
       logger.error("$TAG expecting $interfaceDeclaration as an interface or abstract class.")
       return

--- a/processors/src/test/kotlin/com/alecarnevale/claymore/processor/InterfaceAutoBindsProcessorProviderTest.kt
+++ b/processors/src/test/kotlin/com/alecarnevale/claymore/processor/InterfaceAutoBindsProcessorProviderTest.kt
@@ -191,9 +191,13 @@ class InterfaceAutoBindsProcessorProviderTest {
       import dagger.hilt.components.SingletonComponent
       
       @InterfaceAutoBinds(implementation = Bar::class, component = SingletonComponent::class)
-      interface Foo
+      interface Foo {
+        fun unresolvedSymbolMustNotBotherUs(unresolved: Unresolved)
+      }
 
-      class Bar: Foo
+      class Bar: Foo {
+        override fun unresolvedSymbolMustNotBotherUs(unresolved: Unresolved) {}
+      }
       """,
     )
 


### PR DESCRIPTION
The current implementation of `AutoBindsValidator.isValid` and `InterfaceAutoBindsValidator.isValid` function is too strict: using default ksp validate checks if all the symbols inside the enclosing scope are valid ([link to doc](https://kotlinlang.org/docs/ksp-multi-round.html#default-behavior-for-validation)).

It's possible that some symbols are not already available.